### PR TITLE
update readme how to install the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,18 @@ cd ckanext-external-storage
 virtualenv .venv27
 source .venv27/bin/activate
 ```
-3. Run the following command to bootstrap the entire environment
+
+3. Install the dependencies
+```
+npm install
+```
+
+4. Generate the [ckan3-js-sdk](https://github.com/datopian/ckan3-js-sdk) bundle
+```
+npm run build
+```
+
+5. Run the following command to bootstrap the entire environment
 ```
 make dev-start
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ source .venv27/bin/activate
 npm install
 ```
 
-4. Generate the [ckan3-js-sdk](https://github.com/datopian/ckan3-js-sdk) bundle
+4. Generate a bundle of all client-side dependencies
 ```
 npm run build
 ```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ virtualenv .venv27
 source .venv27/bin/activate
 ```
 
-3. Install the dependencies
+3. Install client-side dependencies
 ```
 npm install
 ```


### PR DESCRIPTION
Add how-to install and build the bundle of the ckan3-js-sdk in readme.md.
e.g
3. Install the dependencies
```
npm install
```

4. Generate the [ckan3-js-sdk](https://github.com/datopian/ckan3-js-sdk) bundle
```
npm run build
```